### PR TITLE
Make compatible with protocol v1 (tested)

### DIFF
--- a/jdk-compatibility.md.txt
+++ b/jdk-compatibility.md.txt
@@ -1,0 +1,8 @@
+jdk1.8.0_202
+does work
+
+jdk-11
+compilation fails with 
+# EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x000000007110b5db, pid=11072, tid=6780
+# Problematic frame:
+# C  [jSSC-2.8_x86_64.dll+0xb5db]


### PR DESCRIPTION
Fixed the following issues:

-when writing date/time v1 needs some delay between the characters or it will go into an undefined mode
-readAvailableDataSring does now account for preceding address and spaces between bytes
-totalBytesToRead does now account for spaces and address
-serialString now reads it's data from the correct position in the string
-pop() did crash if a event was wrapped around a line because the v1 is slow 2400baud the programm reads the first value from the line which it already has, then the stack is empty, the code calles pop() again which returns null which results in a crash. by using while statments and refilling the buffer if the stack is insuficcient this issue is fixed

While compiling I encountered difficulties with the new jdk, therefore a notice on compatibility...
Looking forward to your thought and criticism,
Benjamin